### PR TITLE
Added bash script and Jupyter notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository is used to enable apps in the canvas side nav for courses
 You can use the jupyter notebook or the bash script to change the app visibility. You will need to run a SQL query and export the data into a CSV with `id`, `course_code`, `enrollment_term_id` as the columns.
 ```sql
 select id, course_code, enrollment_term_id
-from canvas.courses as can,
+from canvas.courses can,
 where can.tab_configuration like '%{"id":"context_external_tool_<tool id>","hidden":true}%' and enrollment_term_id='<term id>'
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
 # ATG Canvas Course Enable APP
 This repository is used to enable apps in the canvas side nav for courses
 ## Usage
-You can use the jupyter notebook or the bash script to change the app visibility.
+You can use the jupyter notebook or the bash script to change the app visibility. You will need to run a SQL query and export the data into a CSV with `id`, `course_code`, `enrollment_term_id` as the columns.
+```sql
+select id, course_code, enrollment_term_id
+from canvas.courses as can,
+where can.tab_configuration like '%{"id":"context_external_tool_<tool id>","hidden":true}%' and enrollment_term_id='<term id>'
+```
 
 ### Bash script
 If you are opting to use the bash script you will will need to supply the bash command with the following:

--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # ATG Canvas Course Enable APP
 This repository is used to enable apps in the canvas side nav for courses
+## Usage
+You can use the jupyter notebook or the bash script to change the app visibility.
+
+### Bash script
+If you are opting to use the bash script you will will need to supply the bash command with the following:
+- `-f` with the file path
+- `-h` with the host path similar to the jupyter notebook example
+- `-k` with the api key generated from canvas
+- `-t` with the app tool id(can be found in the canvas data 2 or directly in canvas)
+
+```bash
+bash atg_canvas_course_enable_app.sh -f ../beta_canvas_fall_2024_2025.csv -h 'school.canvas.com' -k 'some-super-secret-key' -t 99999
+```

--- a/atg_canvas_course_enable_app.sh
+++ b/atg_canvas_course_enable_app.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# Parse command line arguments
+while getopts "f:h:k:t:" opt; do
+    case $opt in
+        f)
+            CSV_FILE="$OPTARG"
+            ;;
+        h)
+            URL="$OPTARG"
+            ;;
+        k)
+            API_KEY="$OPTARG"
+            ;;
+        t)
+            TOOL_ID="$OPTARG"
+            ;;
+        \?)
+            echo "Invalid option: -$OPTARG" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# Check if CSV_FILE, URL, API_KEY, and TOOL_ID are set
+if [ -z "$CSV_FILE" ] || [ -z "$URL" ] || [ -z "$API_KEY" ] || [ -z "$TOOL_ID" ]; then
+    echo "Usage: $0 -f <csv_file> -h <url> -k <api_key> -t <tool_id>"
+    exit 1
+fi
+
+headers=1
+
+
+# Skip the headers if the headers variable is set to 1
+if [[ $headers -eq 1 ]]; then
+    tail -n +2 "$CSV_FILE" | while IFS=, read -r id course_code enrollment_term_id
+    do
+        full_url="https://$URL/api/v1/courses/$id/tabs/context_external_tool_$TOOL_ID?hidden=false"
+        # Process each column
+        response=$(curl -s -X PUT "$full_url" \
+            -H "Authorization: Bearer $API_KEY")
+
+        echo "Put URL:" $full_url
+        echo "id: $id"
+        echo "course_code: $course_code"
+        echo "enrollment_term_id: $enrollment_term_id"
+        echo "Response: $response"
+        echo "-------------------"
+    done
+else
+    while IFS=, read -r id course_code enrollment_term_id
+    do
+        full_url="https://$URL/api/v1/courses/$id/tabs/context_external_tool_$TOOL_ID?hidden=false"
+        # Process each column
+        response=$(curl -s -X PUT "$full_url" \
+            -H "Authorization: Bearer $API_KEY")
+        echo "Put URL:" $full_url
+        echo "id: $id"
+        echo "course_code: $course_code"
+        echo "enrollment_term_id: $enrollment_term_id"
+        echo "Response: $response"
+        echo "-------------------"
+    done < "$CSV_FILE"
+fi

--- a/reference_app_visibility.ipynb
+++ b/reference_app_visibility.ipynb
@@ -31,7 +31,7 @@
     "Run this query against your Canvas Data 2 database(credentials are in the `confluence wiki` and in the `tlt-ops` account) and save to a CSV called `hidden_zoom_courses.csv`. You'll need to replace the numeric IDs with the tool and enrollment term IDs from your instance. Note: we only really need the `id` to make the change. You can find the tool's id in canvas or via the API by making a call to `https://{canvas_host}/api/v1/courses/{course_id}/tabs`. This will list out all available tools and their ID's \n",
     "\n",
     "```sql\n",
-    "select id, course_code, created_at, updated_at, sis_source_id, enrollment_term_id, tab_configuration, name\n",
+    "select id, course_code, enrollment_term_id\n",
     "  from canvas.courses as can \n",
     "  where can.tab_configuration like '%{\"id\":\"context_external_tool_<tool id>\",\"hidden\":true}%' and enrollment_term_id='<term id>';\n",
     "```\n"

--- a/reference_app_visibility.ipynb
+++ b/reference_app_visibility.ipynb
@@ -32,7 +32,7 @@
     "\n",
     "```sql\n",
     "select id, course_code, enrollment_term_id\n",
-    "  from canvas.courses as can \n",
+    "  from canvas.courses can \n",
     "  where can.tab_configuration like '%{\"id\":\"context_external_tool_<tool id>\",\"hidden\":true}%' and enrollment_term_id='<term id>';\n",
     "```\n"
    ]

--- a/reference_app_visibility.ipynb
+++ b/reference_app_visibility.ipynb
@@ -1,0 +1,91 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests\n",
+    "import csv"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hidden_nav_file = 'hidden_app_courses.csv'\n",
+    "canvas_host = 'canvas.your-institution.edu'\n",
+    "canvas_admin_token = 'your_api_token_goes_here'\n",
+    "external_tool_id = '12345'\n",
+    "headers = {'Authorization': f'Bearer {canvas_admin_token}'}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1: use Canvas Data to find hidden Zoom nav items\n",
+    "Run this query against your Canvas Data 2 database(credentials are in the `confluence wiki` and in the `tlt-ops` account) and save to a CSV called `hidden_zoom_courses.csv`. You'll need to replace the numeric IDs with the tool and enrollment term IDs from your instance. Note: we only really need the `id` to make the change. You can find the tool's id in canvas or via the API by making a call to `https://{canvas_host}/api/v1/courses/{course_id}/tabs`. This will list out all available tools and their ID's \n",
+    "\n",
+    "```sql\n",
+    "select id, course_code, created_at, updated_at, sis_source_id, enrollment_term_id, tab_configuration, name\n",
+    "  from canvas.courses as can \n",
+    "  where can.tab_configuration like '%{\"id\":\"context_external_tool_<tool id>\",\"hidden\":true}%' and enrollment_term_id='<term id>';\n",
+    "```\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2: Unhide the hidden nav items found in step 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# unhide navs\n",
+    "\n",
+    "with open(hidden_nav_file, 'r') as infile:\n",
+    "    reader = csv.DictReader(infile)\n",
+    "    r = 0;\n",
+    "    for row in reader:\n",
+    "        api_url = f'https://{canvas_host}/api/v1/courses/{row[\"canvas_id\"]}/tabs/context_external_tool_{external_tool_id}?hidden=false'\n",
+    "        response = requests.put(api_url, headers=headers)\n",
+    "        print(response.text)\n",
+    "        r += 1;\n",
+    "        print(f'{r}; ', end='')\n",
+    "\n",
+    "        \n",
+    "print('Done!')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This PR is to add a bash script to unhide a particular canvas course app in the left hand side nav. This should make it easier to update hidden apps in navs(location is not specified currently) for a set/term of courses. The courses would be manually exported from the canvas data 2 database via a SQL query.
```sql
select id, course_code, enrollment_term_id
from canvas.courses can
where can.tab_configuration like '%{"id":"context_external_tool_<tool id>","hidden":true}%' and enrollment_term_id='<term id>'
```